### PR TITLE
Fix FreeBSD build

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.5: QmV6pzBTpFEyoPCFWndHW1y5EM9bpK7j7SELSXyvfmqW8u
+0.0.6: QmT67DXBvSkcuLdygqe9tzuvRuCiaPd61w5a7uKKkg5gmM

--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.6: QmT67DXBvSkcuLdygqe9tzuvRuCiaPd61w5a7uKKkg5gmM
+0.0.7: Qmf4WYXTYCja9thi9U19yMGQqZ7oTf8BP8iUjBtCFyjpMM

--- a/hang-fds.go
+++ b/hang-fds.go
@@ -39,11 +39,19 @@ func fdRaise(nn int) error {
 		return err
 	}
 
-	if rLimit.Cur >= n {
+	if uint64(rLimit.Cur) >= n {
 		fmt.Printf("already at %d >= %d fds\n", rLimit.Cur, n)
 		return nil // all good.
 	}
-	rLimit.Cur = n
+	var i interface{} = &rLimit.Cur
+	switch i := i.(type) {
+	case *uint64:
+		*i = uint64(n)
+	case *int64:
+		*i = int64(n)
+	default:
+		return fmt.Errorf("error message")
+	}
 
 	err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err != nil {
@@ -55,7 +63,7 @@ func fdRaise(nn int) error {
 		return err
 	}
 
-	if rLimit.Cur < n {
+	if uint64(rLimit.Cur) < n {
 		return fmt.Errorf("failed to raise fd limit to %d (still %d)", n, rLimit.Cur)
 	}
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "license": "",
   "name": "hang-fds",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.5"
+  "version": "0.0.6"
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "license": "",
   "name": "hang-fds",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.6"
+  "version": "0.0.7"
 }
 


### PR DESCRIPTION
`rLimit.Cur` is `int64` on FreeBSD. This is needed for go-ipfs sharness to run on freebsd.